### PR TITLE
Add DB index on `block` column for faster queries.

### DIFF
--- a/database/db.dbm
+++ b/database/db.dbm
@@ -236,6 +236,14 @@ FROM
 ]]> </definition>
 </view>
 
+<index name="block_asc" table="public.script_evaluation_events"
+	 concurrent="false" unique="false" fast-update="false" buffering="false" nulls-not-distinct="false"
+	 index-type="btree" factor="0">
+		<idxelement use-sorting="true" nulls-first="false" asc-order="true">
+			<column name="block"/>
+		</idxelement>
+</index>
+
 <constraint name="cost_model_params_fk" type="fk-constr" comparison-type="MATCH SIMPLE"
 	 upd-action="RESTRICT" del-action="RESTRICT" ref-table="public.cost_model_params" table="public.script_evaluation_events">
 	<columns names="cost_model_params" ref-type="src-columns"/>

--- a/database/db.sql
+++ b/database/db.sql
@@ -199,6 +199,7 @@ SELECT
   SEE.EVALUATED_SUCCESSFULLY,
   SEE.EXEC_BUDGET_CPU,
   SEE.EXEC_BUDGET_MEM,
+  CMP.PK AS COST_MODEL_KEY,
   CMP.PARAM_VALUES AS COST_MODEL_PARAM_VALUES,
   SEE.DATUM,
   SEE.REDEEMER,
@@ -211,6 +212,15 @@ FROM
   JOIN COST_MODEL_PARAMS CMP ON SEE.COST_MODEL_PARAMS = CMP.PK;
 -- ddl-end --
 ALTER VIEW public.script_evaluations OWNER TO "plutus-admin";
+-- ddl-end --
+
+-- object: block_asc | type: INDEX --
+-- DROP INDEX IF EXISTS public.block_asc CASCADE;
+CREATE INDEX block_asc ON public.script_evaluation_events
+USING btree
+(
+	block ASC NULLS LAST
+);
 -- ddl-end --
 
 -- object: cost_model_params_fk | type: CONSTRAINT --


### PR DESCRIPTION
Allows to significantly speed up queries that impose a condition on block column, e.g. `where block > ....`