### PR TITLE
Bump `plutus` version to `1.48.0.0` for `run-script-evaluations`

### DIFF
--- a/run-script-evaluations/cabal.project
+++ b/run-script-evaluations/cabal.project
@@ -10,8 +10,8 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2025-02-25T10:59:45Z
-  , cardano-haskell-packages 2025-02-15T18:39:38Z
+  , hackage.haskell.org 2025-06-12T04:42:37Z
+  , cardano-haskell-packages 2025-06-25T13:51:34Z
 
 write-ghc-environment-files: never
 tests: true

--- a/run-script-evaluations/flake.lock
+++ b/run-script-evaluations/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1739645821,
-        "narHash": "sha256-HjAchUMLsiScm8Jyd+I/5YJKUjDp1r+XFzr05d+o+r4=",
+        "lastModified": 1751362725,
+        "narHash": "sha256-RQpTHF6VDPWELM4MHQahZrpEtv6ZxSx8oceWGAzJKco=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "48b941c5729384f38b79c6f473ddbf920cb310ea",
+        "rev": "4a6a3769c8cc8297ae8722e51fa5a4700b2db759",
         "type": "github"
       },
       "original": {
@@ -279,11 +279,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1740443059,
-        "narHash": "sha256-mM5GHiCNA5cwOC+zpRuNq/lmdFJ+mBUMH/bxlazwYDw=",
+        "lastModified": 1751458505,
+        "narHash": "sha256-DlyRi1NXrQYFdk7oH6O5O+XqsIOPIjIrZyOUDqOHwxA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "79e170956b8e805c53666e3cde7198cba9a7268d",
+        "rev": "fbea0a72717000c0452cd1f1adc708f089c9716f",
         "type": "github"
       },
       "original": {

--- a/run-script-evaluations/run-script-evaluations.cabal
+++ b/run-script-evaluations/run-script-evaluations.cabal
@@ -60,7 +60,7 @@ executable run-script-evaluations
     , containers
     , murmur-hash
     , optparse-applicative
-    , plutus-core                 >=1.40.0
+    , plutus-core                 >=1.48.0
     , plutus-ledger-api
     , postgresql-simple
     , prettyprinter-configurable


### PR DESCRIPTION
I don't think it is necessary to bump `index-script-evaluations` until there is new hardfork since simply just pulling data from chain. 