### PR TITLE
Restore the weekly Evaluate job against latest Plutus, and keep it in sync

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -37,6 +37,13 @@ jobs:
             nix-shell -p nix-prefetch-git --run \
             './add_srp.sh --branch "$PLUTUS_BRANCH"'
 
+      - name: Update flake inputs to cover the synced index-state
+        working-directory: run-script-evaluations
+        # add_srp.sh syncs the cabal.project index-state to the pinned Plutus commit.
+        # haskell.nix builds the plan from the pinned hackage.nix / CHaP flake inputs,
+        # so their snapshots must also be recent enough to know those index-states.
+        run: nix flake update hackage CHaP --accept-flake-config
+
       - name: Evaluate
         working-directory: run-script-evaluations
         # START_FROM is passed through env and read as a shell variable for the same reason.

--- a/run-script-evaluations/add_srp.sh
+++ b/run-script-evaluations/add_srp.sh
@@ -98,6 +98,28 @@ log "Nix hash: $NIX_SHA"
 # Create backup of cabal.project
 cp cabal.project cabal.project.backup
 
+# Sync the CHaP/Hackage index-state to the one the pinned Plutus commit was tested
+# against, so we resolve the same package set Plutus itself uses (e.g. the aeson >=2.3
+# / cardano-base >=0.1.5 bumps). We read it from the already-prefetched checkout
+# ($PREFETCHED .path), so this uses the exact pinned commit with no extra network call.
+# The flake inputs still need `nix flake update hackage CHaP` (done in CI) so haskell.nix's
+# snapshots cover these dates.
+PLUTUS_SRC=$(echo "$PREFETCHED" | jq -r .path)
+if [[ -n "$PLUTUS_SRC" && "$PLUTUS_SRC" != "null" && -f "$PLUTUS_SRC/cabal.project" ]]; then
+  DATE_RE='[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z'
+  PLUTUS_HACKAGE_IDX=$(grep -oE "hackage\.haskell\.org[[:space:]]+$DATE_RE" "$PLUTUS_SRC/cabal.project" | grep -oE "$DATE_RE" | head -1)
+  PLUTUS_CHAP_IDX=$(grep -oE "cardano-haskell-packages[[:space:]]+$DATE_RE" "$PLUTUS_SRC/cabal.project" | grep -oE "$DATE_RE" | head -1)
+  if [[ -n "$PLUTUS_HACKAGE_IDX" && -n "$PLUTUS_CHAP_IDX" ]]; then
+    log "Syncing index-state from Plutus (hackage: $PLUTUS_HACKAGE_IDX, CHaP: $PLUTUS_CHAP_IDX)"
+    sed -i -E "s|(hackage\.haskell\.org[[:space:]]+)$DATE_RE|\1$PLUTUS_HACKAGE_IDX|" cabal.project
+    sed -i -E "s|(cardano-haskell-packages[[:space:]]+)$DATE_RE|\1$PLUTUS_CHAP_IDX|" cabal.project
+  else
+    log "Warning: could not parse index-state from Plutus cabal.project; leaving ours unchanged"
+  fi
+else
+  log "Warning: prefetched Plutus checkout has no cabal.project; leaving index-state unchanged"
+fi
+
 # Remove existing Plutus SRP entries to make script idempotent
 log "Removing existing Plutus source-repository-package entries..."
 sed -i '/-- Added by add_srp.sh script/,/plutus-ledger-api/d' cabal.project

--- a/run-script-evaluations/cabal.project
+++ b/run-script-evaluations/cabal.project
@@ -10,8 +10,8 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2026-03-01T00:00:00Z
-  , cardano-haskell-packages 2026-02-25T10:27:50Z
+  , hackage.haskell.org 2026-06-22T23:30:49Z
+  , cardano-haskell-packages 2026-06-18T17:45:00Z
 
 write-ghc-environment-files: never
 tests: true
@@ -22,3 +22,22 @@ packages: .
 
 package postgresql-libpq
   flags: +use-pkg-config
+
+-- Latest plutus master requires aeson >=2.3. The plutus source-repository-package
+-- (appended below by add_srp.sh) brings in plutus-tx / plutus-core / plutus-ledger-api
+-- as local packages, so cabal solves their full component set, including plutus-core's
+-- cost-model-budgeting-bench executable, which pulls in criterion -> microstache.
+--
+-- deriving-aeson:aeson and microstache:aeson mirror plutus master's own cabal.project,
+-- which relaxes those same bounds to admit aeson >=2.3:
+-- https://github.com/IntersectMBO/plutus/blob/master/cabal.project
+--
+-- postgresql-simple:aeson is ours: postgresql-simple still caps aeson <2.3 at its latest
+-- release (0.7.0.1) but builds against 2.3, so we relax it to keep aeson consistent.
+constraints:
+  , setup.optparse-applicative >=0.19.0.0
+
+allow-newer:
+  , deriving-aeson:aeson
+  , microstache:aeson
+  , postgresql-simple:aeson

--- a/run-script-evaluations/flake.lock
+++ b/run-script-evaluations/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1772453365,
-        "narHash": "sha256-AvxnmKrJDvN9fIt5lsMblKbQblASO5P1NM8STk0Ln94=",
+        "lastModified": 1783362288,
+        "narHash": "sha256-U0o77JuGp6ADqym7TtGV3AwzRn5SFuiTRyCOR6qfxGA=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "fb6672e35ea562e405f22533d45663f78b8369cb",
+        "rev": "177c874bc5555d1b907dc310ad1da71a50aeff52",
         "type": "github"
       },
       "original": {
@@ -209,11 +209,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1772455466,
-        "narHash": "sha256-vIMCbV9irO6bcus83zmaKb5jqCCdg4HMLVLxH65mYG8=",
+        "lastModified": 1783408277,
+        "narHash": "sha256-PkZ6wbDZXZQG6hqNFHbqGCHSuuZN7dMi3kxHDbGxQbI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b99ca6c666cb053278c909ec5dd8dd375f80d012",
+        "rev": "c944e2bc7bed38788e39ecb63362b8f11fed1ac6",
         "type": "github"
       },
       "original": {

--- a/run-script-evaluations/run-evaluations/Database/PostgreSQL/Simple/Orphans.hs
+++ b/run-script-evaluations/run-evaluations/Database/PostgreSQL/Simple/Orphans.hs
@@ -3,6 +3,7 @@
 module Database.PostgreSQL.Simple.Orphans where
 
 import Control.Exception (Exception)
+import Data.Int (Int64)
 import Data.SatInt (unsafeToSatInt)
 import Database.PostgreSQL.Simple.FromField (FromField (..), conversionError)
 import PlutusLedgerApi.Common (
@@ -31,4 +32,4 @@ deriving newtype instance FromField ExMemory
 deriving newtype instance FromField ExCPU
 
 instance FromField SatInt where
-  fromField f mdata = unsafeToSatInt <$> fromField @Int f mdata
+  fromField f mdata = unsafeToSatInt <$> fromField @Int64 f mdata


### PR DESCRIPTION
The weekly "Evaluate mainnet scripts" job has been failing in the `Evaluate` step, before any script runs. `add_srp.sh` pulls the latest Plutus master, and current master requires `cardano-base >= 0.1.5` and `aeson >= 2.3`, which our pinned index-state and flake inputs did not admit, so `cabal` could not resolve a build plan.

I reproduced the whole job locally (`add_srp.sh` for the same master commit, then plan resolution and a full build inside `nix develop`) and worked through four layers.

## Fix (first commit)

1. Bump the CHaP and Hackage index-states in `run-script-evaluations/cabal.project` to match Plutus master's own `cabal.project` (`CHaP 2026-06-18` exposes `cardano-base 0.1.5.0`).
2. Update the `hackage` and `CHaP` flake inputs so haskell.nix's pinned snapshots cover those dates. Without this the solver fails with `Cabal-7159` (requested index-state newer than the snapshot).
3. Add the resolution knobs Plutus master uses for the `aeson >= 2.3` cascade (`allow-newer: deriving-aeson:aeson, microstache:aeson`, `constraints: setup.optparse-applicative >=0.19.0.0`), plus `allow-newer: postgresql-simple:aeson` for our own dependency. `postgresql-simple` still caps `aeson < 2.3` at its latest release but builds against 2.3.
4. Adapt `FromField SatInt` to a real Plutus API change: `Data.SatInt` now wraps `Int64`, so it reads the field as `Int64` (`fromField @Int64`), matching `unsafeToSatInt :: Int64 -> SatInt`.

## Prevent recurrence (second commit)

The index-states were hardcoded, so this breaks whenever master moves a bound past our pins. To keep the compatibility test aligned:

- `add_srp.sh` now syncs the `cabal.project` index-state from the pinned Plutus commit's own `cabal.project`, read from the prefetched checkout (exact commit, no extra network call).
- The workflow runs `nix flake update hackage CHaP` after `add_srp.sh` so the flake snapshots cover the synced dates.

`allow-newer`/`constraints` stay hardcoded: they change rarely, and `postgresql-simple:aeson` is our own relaxation rather than one Plutus master carries.

## Verification

Both executables (`run-script-evaluations` and `value-statistics`) build against Plutus master (`266f6a0`) under GHC 9.6.6. `fourmolu` and `hlint` are clean, `shellcheck` passes on `add_srp.sh`. The runtime evaluation itself needs the mainnet database, so it is not exercised here.
