### PR TITLE
fix: retain checkpoint block events on indexer restart

### DIFF
--- a/index-script-evaluations/lib/Database/Query.hs
+++ b/index-script-evaluations/lib/Database/Query.hs
@@ -27,6 +27,7 @@ import Opaleye (
   toFields,
   where_,
   (.==),
+  (.>),
   (.>=),
  )
 import Opaleye.Internal.Column (SqlNum (pgFromInteger))
@@ -129,13 +130,21 @@ insertScriptEvaluationEvents conn events =
         , iOnConflict = Nothing
         }
 
-deleteFromSlotOnwards :: Connection -> SlotNo -> IO Int
-deleteFromSlotOnwards conn slotNo =
+{- | Delete all events strictly after the given slot.
+
+On resume the indexer intersects chain-sync at the last checkpoint slot @S@ and
+the node replays blocks strictly after @S@ (block @S@ itself is never sent
+again). The checkpoint block is fully processed, so its events must be retained;
+deleting with @>=@ would drop them permanently. We therefore delete with @>@ to
+clear only the not-yet-checkpointed blocks that will be replayed.
+-}
+deleteAfterSlot :: Connection -> SlotNo -> IO Int
+deleteAfterSlot conn slotNo =
   fromIntegral -- Convert from Int64 to Int as we don't expect many rows
     <$> runDelete
       conn
       Delete
         { dTable = scriptEvaluationEvents
-        , dWhere = \r -> eeSlotNo r .>= toFields slotNo
+        , dWhere = \r -> eeSlotNo r .> toFields slotNo
         , dReturning = rCount
         }

--- a/index-script-evaluations/lib/Database/Query.hs
+++ b/index-script-evaluations/lib/Database/Query.hs
@@ -148,3 +148,21 @@ deleteAfterSlot conn slotNo =
         , dWhere = \r -> eeSlotNo r .> toFields slotNo
         , dReturning = rCount
         }
+
+{- | Delete every recorded event.
+
+Used when the indexer resumes from genesis (no checkpoint yet): the whole chain
+is replayed, so any pre-existing rows must be cleared to avoid stale or
+duplicated events. Unlike 'deleteAfterSlot', there is no checkpoint block to
+preserve, so the delete is unconditional.
+-}
+deleteAllEvents :: Connection -> IO Int
+deleteAllEvents conn =
+  fromIntegral -- Convert from Int64 to Int as we don't expect many rows
+    <$> runDelete
+      conn
+      Delete
+        { dTable = scriptEvaluationEvents
+        , dWhere = const (toFields True)
+        , dReturning = rCount
+        }

--- a/index-script-evaluations/load-script-events/Load.hs
+++ b/index-script-evaluations/load-script-events/Load.hs
@@ -11,7 +11,6 @@ import Cardano.Api (
   chainPointToSlotNo,
  )
 import Data.ByteString (ByteString)
-import Data.Maybe (fromMaybe)
 import Data.String.Interpolate (i)
 import Database qualified as Db
 import Database.PostgreSQL.Simple (Connection)
@@ -47,9 +46,17 @@ loadScriptEvents conn Options{..} = do
 
   putStrLn $ Render.startChainPoint chainPoint
 
-  let slot = fromMaybe 0 (chainPointToSlotNo chainPoint)
-  numDeleted <- Db.deleteAfterSlot conn slot
-  putStrLn [i|Deleted #{numDeleted} events (slot > #{slot}).|]
+  -- Clear events that will be re-inserted on replay. From a real checkpoint at
+  -- slot S the node replays blocks strictly after S, so block S is retained and
+  -- we delete only slot > S. From genesis (no checkpoint) the whole chain is
+  -- replayed, so every existing row is deleted.
+  case chainPointToSlotNo chainPoint of
+    Nothing -> do
+      numDeleted <- Db.deleteAllEvents conn
+      putStrLn [i|Deleted #{numDeleted} events (all; replaying from genesis).|]
+    Just slot -> do
+      numDeleted <- Db.deleteAfterSlot conn slot
+      putStrLn [i|Deleted #{numDeleted} events (slot > #{slot}).|]
 
   ensureDir checkpointsDir
   subscribeToChainSyncEvents optsSocketPath optsNetworkId [chainPoint]

--- a/index-script-evaluations/load-script-events/Load.hs
+++ b/index-script-evaluations/load-script-events/Load.hs
@@ -48,8 +48,8 @@ loadScriptEvents conn Options{..} = do
   putStrLn $ Render.startChainPoint chainPoint
 
   let slot = fromMaybe 0 (chainPointToSlotNo chainPoint)
-  numDeleted <- Db.deleteFromSlotOnwards conn slot
-  putStrLn [i|Deleted #{numDeleted} events (slot >= #{slot}).|]
+  numDeleted <- Db.deleteAfterSlot conn slot
+  putStrLn [i|Deleted #{numDeleted} events (slot > #{slot}).|]
 
   ensureDir checkpointsDir
   subscribeToChainSyncEvents optsSocketPath optsNetworkId [chainPoint]


### PR DESCRIPTION
Fixes IntersectMBO/plutus-private#2272.

The database indexer permanently loses the script-evaluation events in the checkpoint block on every restart. The loss is silent and needs no crash.

## Mechanism

On startup, `loadScriptEvents` reads the last checkpoint at slot `S` and calls `deleteFromSlotOnwards conn S`, which deletes every row with `slot >= S`, including the checkpoint block itself. It then resumes chain-sync from the intersection at `S`. The node's next roll-forward is the block strictly after `S`, so block `S` is never sent again, and the initial roll-backward to the starting point is a no-op. The events in block `S` are deleted and never re-inserted.

The indexer checkpoints every 10,000 blocks, so repeated restarts leave gaps precisely at the checkpoint blocks whenever such a block contained Plutus script events. Downstream replay then runs against an incomplete corpus, and nothing surfaces the loss.

## Fix

Delete strictly after the checkpoint (`slot > S`) instead of `slot >= S`. This matches what the checkpoint already means: fully processed up to and including `S`. The confirmed block is retained, and blocks after `S` are still cleared and re-applied when the node replays them.

- `Database/Query.hs`: renamed `deleteFromSlotOnwards` (`>=`) to `deleteAfterSlot` (`>`), with a note explaining why the boundary is exclusive.
- `Load.hs`: updated the call site and the log message.

One correction to the issue: it says inserts use `ON CONFLICT DO NOTHING`, so either boundary would be safe against duplicates. In fact `insertScriptEvaluationEvents` uses `iOnConflict = Nothing` (abort on conflict). The fix is still safe, because block `S` is never replayed, so no conflicting re-insert can happen for it, and blocks after `S` are deleted before being re-applied.

## Verification

- `fourmolu --mode check` on both files: clean.
- Built the `index-script-evaluations` library and the `load-script-events` executable through the project's haskell.nix flake, the same path CI uses, with the pinned `index-state`. Both compile and link.
