### PR TITLE
fix: persist the checkpoint after inserting the block's events

### DIFF
--- a/index-script-evaluations/load-script-events/LedgerEvents/DbLoader.hs
+++ b/index-script-evaluations/load-script-events/LedgerEvents/DbLoader.hs
@@ -64,15 +64,7 @@ makeEventIndexer
 makeEventIndexer checkpointDir conn = do
   pure \(blockNo, checkpoint@Checkpoint{cChainPoint}, ledgerEvents) -> do
     let slotNo = fromMaybe (SlotNo 0) (chainPointToSlotNo cChainPoint)
-    when (unBlockNo blockNo `mod` 10_000 == 0) do
-      putStrLn "Writing ledger state ... "
-      FileStorage.saveLedgerState checkpointDir checkpoint
-      putStrLn "Done."
-      putStrLn "Cleaning up old ledger states..."
-      FileStorage.cleanupLedgerStates checkpointDir
-      putStrLn "Done."
-
-    let eventRecords = indexLedgerEvents slotNo blockNo ledgerEvents
+        eventRecords = indexLedgerEvents slotNo blockNo ledgerEvents
         scriptEvaluationRecords = nub $ eventRecords <&> event
         costsRecords = nub $ eventRecords >>= maybeToList . costs
         scriptRecords = nub $ eventRecords <&> script
@@ -90,6 +82,21 @@ makeEventIndexer checkpointDir conn = do
     numEvents <- DB.insertScriptEvaluationEvents conn scriptEvaluationRecords
     unless (numEvents == 0) do
       putStrLn [i|Inserted #{numEvents} script evaluation events.|]
+
+    -- Persist the checkpoint only after this block's events have been inserted.
+    -- Each insert above runs in autocommit mode, so once they return the block's
+    -- events are durably stored. Saving the checkpoint last guarantees that a
+    -- crash can never leave the checkpoint pointing at a block whose events did
+    -- not reach the database: on resume the node replays blocks strictly after
+    -- the checkpoint, so a checkpoint block with missing events would never be
+    -- re-applied and those events would be lost silently.
+    when (unBlockNo blockNo `mod` 10_000 == 0) do
+      putStrLn "Writing ledger state ... "
+      FileStorage.saveLedgerState checkpointDir checkpoint
+      putStrLn "Done."
+      putStrLn "Cleaning up old ledger states..."
+      FileStorage.cleanupLedgerStates checkpointDir
+      putStrLn "Done."
 
 data EventRecords = MkEventRecords
   { event :: DB.EvaluationEventRecord


### PR DESCRIPTION
Fixes IntersectMBO/plutus-private#2274.

## Problem

In the database indexer, the checkpoint for a block was written before that block's events were inserted. For every block where `blockNo mod 10000 == 0`, `makeEventIndexer` ran `saveLedgerState` at the top of the handler, ahead of `insertCostModelValues` / `insertSerialisedScripts` / `insertScriptEvaluationEvents`.

If the process was interrupted after the checkpoint was persisted but before the inserts committed, the checkpoint pointed at block `S` while `S`'s events were not in the database. On resume the indexer intersects chain-sync at `S` and the node replays blocks strictly after `S`, so `S` is never re-applied and its events are lost with no error.

## Fix

Move the checkpoint write to the end of the handler, after the three inserts. Each insert runs in autocommit mode, so once they return the block's events are durably stored. Writing the checkpoint last makes "checkpoint reached" imply "the block's events are in the database".

The two `let` blocks that the checkpoint code used to sit between are merged into one, since nothing separates them anymore.

## Scope

This addresses only the ordering defect. The two sibling issues are left alone:

- The inclusive `>=` delete plus no replay of the checkpoint block on restart (plutus-private#2272).
- The same checkpoint-before-write ordering in the dump writer (plutus-private#2273).

## Verification

- `fourmolu --mode check` passes on the changed module.
- `cabal build --dry-run` resolves the project (the `.cabal`/`cabal.project` parse and the plan computes).
- `ghc -fno-code` typechecks the changed module's local dependency graph (`Database`, `Database.Query`, `Database.Schema`, `Database.Orphans`, `Render`, `Types`, `FileStorage`) against the dev-shell package db.

A full `cabal build` was not run: with the pinned index-state the solver rebuilds the entire cardano stack from source, and there is no working `nix build` target for this package (`nix/outputs.nix` references GHC variants that `nix/project.nix` does not declare). The change is a relocation of an existing `IO ()` block plus a `let` merge, with no new identifiers, imports, or types.
