### PR TITLE
fix: write the event file before persisting the checkpoint

### DIFF
--- a/index-script-evaluations/lib/LedgerEvents/FileWriter.hs
+++ b/index-script-evaluations/lib/LedgerEvents/FileWriter.hs
@@ -84,48 +84,66 @@ makeEventIndexer checkpointsDir eventsDir (fromIntegral -> eventsPerFile) = do
     let MkPlutusEvents{..} = indexLedgerEvents ledgerEvents
     state@EventHandlerState{..} <- readIORef ref
     let numNewEvents = length peScriptEvaluationEvents
+        totalEvents = numScriptEvents + numNewEvents
+        bufferedEvents = scriptEvents <> peScriptEvaluationEvents
+        costParamsV1' = costParamsV1 <|> peCostParamsV1
+        costParamsV2' = costParamsV2 <|> peCostParamsV2
     putStrLn
       [__i|
-      Total script events: #{numScriptEvents + numNewEvents} (+#{numNewEvents})
+      Total script events: #{totalEvents} (+#{numNewEvents})
       |]
-    if numScriptEvents + numNewEvents >= eventsPerFile
+    if totalEvents >= eventsPerFile
       then do
-        let (eventsToWrite, eventsToCarry) =
-              splitAt eventsPerFile $
-                DList.toList (scriptEvents <> peScriptEvaluationEvents)
+        -- Flush the entire buffer as a single file keyed by the current block's
+        -- chain point, so the file boundary lines up with the checkpoint block.
+        --
+        -- Write the events BEFORE persisting the checkpoint. If the process
+        -- dies in between, the checkpoint stays behind the data: resume replays
+        -- the blocks after the previous checkpoint and deterministically
+        -- rewrites this same (chain-point-keyed) file, so nothing is lost. The
+        -- reverse order can permanently drop a whole file's worth of events if
+        -- interrupted before the write.
+        --
+        -- We flush the whole buffer rather than splitting at exactly
+        -- eventsPerFile and carrying the remainder. Carried events belong to
+        -- the checkpoint block, which resume never replays (it resumes strictly
+        -- after the checkpoint), so any carry would be lost on every restart.
+        -- The file therefore slightly overshoots eventsPerFile (by at most one
+        -- block's events); eventsPerFile is a soft target, not an exact size.
+        let eventsToWrite = DList.toList bufferedEvents
+        putStrLn $
+          "Writing " <> show totalEvents <> " script events..."
+        FileStorage.saveEvents
+          eventsDir
+          chainPoint
+          ScriptEvaluationEvents
+            { eventsCostParamsV1 = strictMaybeToMaybe costParamsV1'
+            , eventsCostParamsV2 = strictMaybeToMaybe costParamsV2'
+            , eventsEvents = NE.fromList eventsToWrite
+            }
+        putStrLn "Done."
         putStrLn "Writing ledger state ... "
         FileStorage.saveLedgerState checkpointsDir checkpoint
         putStrLn "Done."
         putStrLn "Cleaning up old ledger states..."
         FileStorage.cleanupLedgerStates checkpointsDir
         putStrLn "Done."
-        putStrLn $
-          "Writing " <> show (length eventsToWrite) <> " script events..."
-        FileStorage.saveEvents
-          eventsDir
-          chainPoint
-          ScriptEvaluationEvents
-            { eventsCostParamsV1 = strictMaybeToMaybe costParamsV1
-            , eventsCostParamsV2 = strictMaybeToMaybe costParamsV2
-            , eventsEvents = NE.fromList eventsToWrite
-            }
-        putStrLn "Done."
         writeIORef
           ref
           state
-            { costParamsV1 = costParamsV1 <|> peCostParamsV1
-            , costParamsV2 = costParamsV2 <|> peCostParamsV2
-            , scriptEvents = DList.fromList eventsToCarry
-            , numScriptEvents = numScriptEvents + numNewEvents - eventsPerFile
+            { costParamsV1 = costParamsV1'
+            , costParamsV2 = costParamsV2'
+            , scriptEvents = DList.empty
+            , numScriptEvents = 0
             }
       else
         writeIORef
           ref
           state
-            { costParamsV1 = costParamsV1 <|> peCostParamsV1
-            , costParamsV2 = costParamsV2 <|> peCostParamsV2
-            , scriptEvents = scriptEvents <> peScriptEvaluationEvents
-            , numScriptEvents = numScriptEvents + numNewEvents
+            { costParamsV1 = costParamsV1'
+            , costParamsV2 = costParamsV2'
+            , scriptEvents = bufferedEvents
+            , numScriptEvents = totalEvents
             }
 
 data PlutusEvents = MkPlutusEvents


### PR DESCRIPTION
The dump writer persisted the checkpoint before writing the buffered `.event` file, so an interruption between the two advanced the checkpoint past events that were never written; resume never re-derives them, so up to a full file is dropped. This writes the events first: after a crash the checkpoint stays behind the data, which resume handles by replaying the blocks after the previous checkpoint and rewriting the same chain-point-keyed file.

Reordering alone isn't enough. The writer buffered events across blocks and split the buffer at exactly `events-per-file`, carrying the remainder forward. Those carried events belong to the checkpoint (flush-triggering) block, and resume restarts strictly after the checkpoint, so that block is never replayed. The carry was therefore lost on every restart, not only on a mistimed crash. This now flushes the whole buffer at the block boundary and clears it, so a file overshoots `events-per-file` by at most one block's events. Exact file sizes can't coexist with checkpoint-aligned crash safety anyway: a checkpoint sits on a whole-block boundary while the `events-per-file` cut falls mid-block.

Fixes IntersectMBO/plutus-private#2273. Same ordering defect that #42 fixed in the database indexer.
