### PR TITLE
Fail fast when a script evaluation worker dies

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 1440
     steps:
       - name: Checkout this Repo
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@v5.1.0
 
       - name: Add plutus SRP to the cabal.project
         id: update_cabal_project

--- a/.github/workflows/slack-message-broker.yml
+++ b/.github/workflows/slack-message-broker.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Prepare Slack Message
-        uses: actions/github-script@v7.1.0
+        uses: actions/github-script@v8.0.0
         id: prepare-slack-message
 
         # Pass event data through env and read it via process.env in the script.
@@ -90,7 +90,7 @@ jobs:
 
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v3.0.5
         if: ${{ steps.prepare-slack-message.outputs.shouldSendMessage == 'true' }}
         with:
           method: chat.postMessage

--- a/run-script-evaluations/run-evaluations/Evaluate.hs
+++ b/run-script-evaluations/run-evaluations/Evaluate.hs
@@ -37,10 +37,10 @@ import PlutusLedgerApi.Common (
 import PlutusLedgerApi.V1 qualified as V1
 import PlutusLedgerApi.V2 qualified as V2
 import PlutusLedgerApi.V3 qualified as V3
-import System.Exit (ExitCode (..), exitWith)
+import System.Exit (ExitCode (..))
 import Text.PrettyBy qualified as Pretty
 import UnliftIO (IORef, MonadIO, atomicModifyIORef', liftIO, newIORef, readIORef, writeIORef)
-import UnliftIO.Concurrent (forkFinally, threadDelay)
+import UnliftIO.Concurrent (forkFinally, myThreadId, threadDelay, throwTo)
 
 data ScriptEvaluationInput = MkScriptEvaluationInput
   { seiPlutusLedgerLanguage :: PlutusLedgerLanguage
@@ -83,6 +83,7 @@ evaluateScripts
   -> IO ()
 evaluateScripts conn startFrom callback = do
   maxThreads <- liftIO getNumCapabilities
+  mainThread <- liftIO myThreadId
   st <-
     newIORef
       ( 0 -- current number of threads
@@ -105,9 +106,14 @@ evaluateScripts conn startFrom callback = do
             , nominalDiffTimeToMillis (end `diffUTCTime` startEvaluation)
             )
     _threadId <- forkFinally work \case
-      Left err -> liftIO do
-        putStrLn $ "Failed to evaluate script: " <> show err
-        exitWith (ExitFailure 1)
+      Left err -> do
+        atomicModifyIORef' st \(threads, n, pt, et) -> ((threads - 1, n, pt, et), ())
+        liftIO do
+          putStrLn $ "Failed to evaluate script: " <> show err
+          -- 'exitWith' would only kill this worker thread: an 'ExitCode' thrown in
+          -- a forked thread is caught by its default handler and the process keeps
+          -- running. Throw to the main thread so the whole process exits.
+          throwTo mainThread (ExitFailure 1)
       Right (!dtp, !dte) -> do
         atomicModifyIORef' st \(threads, n, pt, et) ->
           let pt' =


### PR DESCRIPTION
`exitWith` from a `forkFinally`'d worker only throws `ExitCode` inside that worker thread: the child thread's default handler prints it and the process keeps running. Every worker failure therefore leaked a concurrency slot, since the counter is decremented only on the `Right` path, and after `getNumCapabilities` failures `waitForAFreeThread` spins forever, stalling the run instead of aborting it. The failure path now decrements the counter and throws the `ExitCode` to the main thread, which terminates the process with exit code 1 as intended.

I verified both directions with standalone GHC tests of the same pattern: `exitWith` in a forked thread leaves the process running, while `throwTo` the main thread exits 1 immediately. The package builds with the change (GHC 9.6.6), fourmolu and hlint are clean.

Along the way this bumps the workflow actions off the deprecated Node 20 runtime, each to the smallest major that targets node24 and changes nothing else: checkout v4.3.0 to v5.1.0, github-script v7.1.0 to v8.0.0, slack-github-action v2.1.0 to v3.0.5.

Reported in GHSA-36wf-7f68-2pww. Fixes IntersectMBO/plutus-private#2364.
